### PR TITLE
Add WebRTC Leak Detection via STUN

### DIFF
--- a/speedtest.sh
+++ b/speedtest.sh
@@ -64,7 +64,7 @@ parse_args() {
 }
 
 check_dependencies() {
-    local deps=(curl ping awk bc jq)
+    local deps=(curl ping awk bc jq python3)
     for cmd in "${deps[@]}"; do
         if ! command -v "$cmd" &>/dev/null; then
             log_error "Missing required command: $cmd"
@@ -147,6 +147,9 @@ get_ip_info() {
     fi
 
     MY_LOC="${MY_CITY}, ${MY_COUNTRY}"
+    
+    log_info "Performing WebRTC Leak Check (UDP)..."
+    WEBRTC_IP=$(python3 webrtc_check.py 2>/dev/null || echo "Unknown")
 }
 
 test_ping() {
@@ -281,6 +284,19 @@ run_report() {
     printf "  %-14s : %s (%s)\\n" "Region" "$MY_REGION" "$MY_CONTINENT" >&2
     printf "  %-14s : %s (AS%s)\\n" "Provider" "$MY_ISP" "$MY_ASN" >&2
     printf "  %-14s : %s\\n" "Timezone" "$MY_TIMEZONE" >&2
+    
+    # WebRTC Leak Check
+    if [[ "$WEBRTC_IP" != "Unknown" ]]; then
+        if [[ "$MY_IP" != "$WEBRTC_IP" ]]; then
+            printf "  %-14s : ${RED}%s${NC} (via UDP)\\n" "WebRTC IP" "$WEBRTC_IP" >&2
+            printf "  %-14s : ${RED}⚠️  LEAK DETECTED${NC}\\n" "Leak Status" >&2
+        else
+            printf "  %-14s : ${GREEN}%s${NC}\\n" "WebRTC IP" "$WEBRTC_IP" >&2
+            printf "  %-14s : ${GREEN}SECURE${NC}\\n" "Leak Status" >&2
+        fi
+    else
+        printf "  %-14s : ${YELLOW}Check Failed${NC}\\n" "WebRTC IP" >&2
+    fi
     
     if [[ -n "$PROXY" ]]; then
         printf "  %-14s : ${PURPLE}%s${NC}\\n" "Proxy" "ON (Active)" >&2

--- a/webrtc_check.py
+++ b/webrtc_check.py
@@ -1,0 +1,58 @@
+import socket
+import struct
+import random
+import sys
+
+def get_stun_ip(server="stun.l.google.com", port=19302):
+    # STUN Binding Request
+    # 0x0001 = Binding Request
+    # 0x0000 = Message length
+    # 0x2112a442 = Magic Cookie
+    # 12-byte Transaction ID
+    transaction_id = bytes(random.getrandbits(8) for _ in range(12))
+    packet = struct.pack(">HHI12s", 0x0001, 0x0000, 0x2112a442, transaction_id)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(2.0)
+    try:
+        sock.sendto(packet, (server, port))
+        data, addr = sock.recvfrom(2048)
+        
+        # Simple parsing of STUN response
+        # Attributes start at byte 20
+        pos = 20
+        while pos < len(data):
+            attr_type, attr_len = struct.unpack(">HH", data[pos:pos+4])
+            # 0x0001 = MAPPED-ADDRESS, 0x0020 = XOR-MAPPED-ADDRESS
+            if attr_type == 0x0001:
+                # Family (1 byte), Port (2 bytes), Address (4 bytes)
+                family, port, a, b, c, d = struct.unpack(">x B H B B B B", data[pos+4:pos+12])
+                return f"{a}.{b}.{c}.{d}"
+            elif attr_type == 0x0020:
+                # Family (1 byte), Port (2 bytes), XOR Address (4 bytes)
+                family, xport, xaddr = struct.unpack(">x B H I", data[pos+4:pos+12])
+                # XOR-Address = XORed with Magic Cookie (0x2112a442)
+                ip_int = xaddr ^ 0x2112a442
+                return socket.inet_ntoa(struct.pack(">I", ip_int))
+            
+            # Align to 4 bytes
+            pos += 4 + attr_len
+            if attr_len % 4 != 0:
+                pos += (4 - (attr_len % 4))
+        return None
+    except Exception as e:
+        return None
+    finally:
+        sock.close()
+
+if __name__ == "__main__":
+    ip = get_stun_ip()
+    if ip:
+        print(ip)
+    else:
+        # Fallback to cloudflare
+        ip = get_stun_ip("stun.cloudflare.com", 3478)
+        if ip:
+            print(ip)
+        else:
+            sys.exit(1)


### PR DESCRIPTION
This PR introduces a WebRTC leak detection check:
- Added `webrtc_check.py` for UDP STUN requests.
- Integrated the check into `speedtest.sh`.
- Reports potential UDP leaks if the STUN-derived IP differs from the HTTP-derived IP.
- Closes #4